### PR TITLE
Add single blog post page

### DIFF
--- a/css/post.css
+++ b/css/post.css
@@ -1,0 +1,20 @@
+.post-container {
+  padding: var(--spacing-3xl) 0;
+}
+
+.post-title {
+  font-size: var(--font-size-3xl);
+  margin-bottom: var(--spacing-md);
+  color: var(--color-primary);
+}
+
+.post-date {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-xl);
+  display: block;
+}
+
+.post-content {
+  line-height: 1.7;
+}

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                     <article class="blog-card">
                         <div class="card-content">
                             <h3 class="card-title">
-                                <a href="blog.html#text-1" data-ru="Размышления о культуре" data-en="Thoughts on culture">
+                                <a href="post.html?file=post1.md" data-ru="Размышления о культуре" data-en="Thoughts on culture">
                                     Размышления о культуре
                                 </a>
                             </h3>
@@ -109,7 +109,7 @@
                     <article class="blog-card">
                         <div class="card-content">
                             <h3 class="card-title">
-                                <a href="blog.html#text-2" data-ru="Технологии будущего" data-en="Future technologies">
+                                <a href="post.html?file=post2.md" data-ru="Технологии будущего" data-en="Future technologies">
                                     Технологии будущего
                                 </a>
                             </h3>
@@ -123,7 +123,7 @@
                     <article class="blog-card">
                         <div class="card-content">
                             <h3 class="card-title">
-                                <a href="blog.html#text-3" data-ru="Предпринимательство в IT" data-en="Entrepreneurship in IT">
+                                <a href="post.html?file=post3.md" data-ru="Предпринимательство в IT" data-en="Entrepreneurship in IT">
                                     Предпринимательство в IT
                                 </a>
                             </h3>

--- a/js/blog.js
+++ b/js/blog.js
@@ -16,7 +16,7 @@ class BlogPage {
       const card = document.createElement('article')
       card.className = 'blog-card'
       card.innerHTML = `
-        <h3><a href="#" data-file="${post.file}">${post.title}</a></h3>
+        <h3><a href="post.html?file=${post.file}">${post.title}</a></h3>
         <p>${post.excerpt}</p>
         <time datetime="${post.date}">${this.formatDate(post.date)}</time>
       `

--- a/js/post.js
+++ b/js/post.js
@@ -1,0 +1,51 @@
+class BlogPostPage {
+  async init() {
+    const params = new URLSearchParams(window.location.search)
+    const file = params.get('file')
+    if (!file) {
+      document.getElementById('post-content').textContent = 'Post not found'
+      return
+    }
+    try {
+      const res = await fetch('posts/' + file)
+      const text = await res.text()
+      const { meta, content } = this.parseFrontmatter(text)
+      if (meta.title) {
+        document.getElementById('post-title').textContent = meta.title
+        document.title = meta.title + ' - Еремей Дмитриенко'
+      }
+      if (meta.date) {
+        const dateEl = document.getElementById('post-date')
+        dateEl.setAttribute('datetime', meta.date)
+        dateEl.textContent = this.formatDate(meta.date)
+      }
+      document.getElementById('post-content').innerHTML = marked.parse(content)
+    } catch (e) {
+      document.getElementById('post-content').textContent = 'Unable to load post'
+    }
+  }
+
+  parseFrontmatter(md) {
+    const match = md.match(/^---\n([\s\S]*?)\n---\n/)
+    const meta = {}
+    let body = md
+    if (match) {
+      match[1].split(/\n/).forEach((line) => {
+        const [k, ...r] = line.split(':')
+        meta[k.trim()] = r.join(':').trim()
+      })
+      body = md.slice(match[0].length)
+    }
+    return { meta, content: body }
+  }
+
+  formatDate(str) {
+    const d = new Date(str)
+    return d.toLocaleDateString('ru-RU', { year: 'numeric', month: 'long', day: 'numeric' })
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const page = new BlogPostPage()
+  page.init()
+})

--- a/post.html
+++ b/post.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Пост - Еремей Дмитриенко</title>
+    <meta name="description" content="Запись блога">
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="css/blog.css">
+    <link rel="stylesheet" href="css/post.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header" role="banner">
+        <nav class="nav" role="navigation" aria-label="Основная навигация">
+            <div class="nav-container">
+                <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
+                <ul class="nav-menu" id="nav-menu">
+                    <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
+                    <li><a href="blog.html" class="nav-link active" data-ru="Блог" data-en="Blog">Блог</a></li>
+                    <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
+                    <li><a href="culttech.html" class="nav-link" data-ru="CultTech Hub" data-en="CultTech Hub">CultTech Hub</a></li>
+                    <li><a href="contacts.html" class="nav-link" data-ru="Контакты" data-en="Contacts">Контакты</a></li>
+                </ul>
+                <div class="nav-controls">
+                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
+                        <span class="lang-current">RU</span>
+                    </button>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </button>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <main class="main" role="main">
+        <article class="post-container">
+            <div class="container">
+                <h1 id="post-title" class="post-title"></h1>
+                <time id="post-date" class="post-date" datetime=""></time>
+                <div id="post-content" class="post-content"></div>
+            </div>
+        </article>
+    </main>
+
+    <footer class="footer" role="contentinfo">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-info">
+                    <p class="footer-text" data-ru="© 2025 Еремей. Все права защищены." data-en="© 2025 Eremeya. All rights reserved.">
+                        © 2025 Еремей. Все права защищены.
+                    </p>
+                </div>
+                <div class="footer-links">
+                    <a href="contacts.html" class="footer-link" data-ru="Контакты" data-en="Contacts">Контакты</a>
+                    <a href="blog.html" class="footer-link" data-ru="Блог" data-en="Blog">Блог</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/main.js"></script>
+    <script src="js/post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `post.html` page
- load markdown posts in new `post.js`
- style posts with `post.css`
- link blog cards to the new page
- update homepage links accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68499427b314832caf246edb3ae84a39