### PR TITLE
Style search field and improve post errors

### DIFF
--- a/css/blog.css
+++ b/css/blog.css
@@ -32,10 +32,12 @@
   margin: 0 auto var(--spacing-xl) auto;
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .search-input {
   width: 100%;
+  max-width: 280px;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
@@ -127,5 +129,15 @@
 
   .blog-subtitle {
     font-size: var(--font-size-base);
+  }
+
+  .blog-search {
+    flex-direction: column;
+  }
+
+  .search-btn {
+    margin-left: 0;
+    margin-top: var(--spacing-sm);
+    width: 100%;
   }
 }

--- a/js/post.js
+++ b/js/post.js
@@ -8,20 +8,28 @@ class BlogPostPage {
     }
     try {
       const res = await fetch('posts/' + file)
+      if (!res.ok) {
+        throw new Error(res.status + ' ' + res.statusText)
+      }
       const text = await res.text()
       const { meta, content } = this.parseFrontmatter(text)
+
       if (meta.title) {
         document.getElementById('post-title').textContent = meta.title
         document.title = meta.title + ' - Еремей Дмитриенко'
       }
+
       if (meta.date) {
         const dateEl = document.getElementById('post-date')
         dateEl.setAttribute('datetime', meta.date)
         dateEl.textContent = this.formatDate(meta.date)
       }
+
       document.getElementById('post-content').innerHTML = marked.parse(content)
     } catch (e) {
-      document.getElementById('post-content').textContent = 'Unable to load post'
+      const msg = e && e.message ? e.message : 'Unknown error'
+      document.getElementById('post-content').textContent =
+        'Не удалось загрузить пост: ' + msg
     }
   }
 


### PR DESCRIPTION
## Summary
- style `.search-input` and center `.blog-search`
- add responsive rules for smaller screens
- handle HTTP errors in `post.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849a2960928832c89014cf7c4edd0e4