### PR TITLE
Refactor header layout and language dropdown

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -17,7 +17,7 @@
             <div class="nav-container">
                 <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
 
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link active" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -26,10 +26,19 @@
                 </ul>
 
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>

--- a/contacts.html
+++ b/contacts.html
@@ -46,7 +46,7 @@
             <div class="nav-container">
                 <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
 
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -55,10 +55,19 @@
                 </ul>
 
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>

--- a/css/styles.css
+++ b/css/styles.css
@@ -200,6 +200,7 @@ a:focus {
   }
 }
 
+
 .nav-container {
   display: flex;
   align-items: center;
@@ -208,7 +209,7 @@ a:focus {
   height: 100%;
   max-width: var(--container-max-width);
   margin: 0 auto;
-  padding: 0 var(--spacing-lg);
+  padding: 0 var(--spacing-lg) 0 var(--spacing-xl);
 }
 
 .logo {
@@ -216,6 +217,7 @@ a:focus {
   font-weight: 700;
   color: var(--color-primary);
   text-decoration: none;
+  margin-right: var(--spacing-xl);
 }
 
 .nav-menu {
@@ -244,14 +246,15 @@ a:focus {
   color: var(--color-primary);
 }
 
+.nav-link.active {
+  font-weight: 700;
+  background-color: var(--color-accent-50);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
 .nav-link.active::after {
-  content: "";
-  position: absolute;
-  bottom: -3px;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background-color: var(--color-accent);
+  display: none;
 }
 
 .nav-controls {
@@ -260,7 +263,14 @@ a:focus {
   gap: var(--spacing-lg);
 }
 
+.language-selector {
+  position: relative;
+}
+
 .lang-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
   background: none;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
@@ -272,10 +282,46 @@ a:focus {
   transition: all var(--transition-fast);
 }
 
+.lang-icon {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
 .lang-toggle:hover {
   border-color: var(--color-accent);
   background-color: var(--color-accent);
   color: white;
+}
+
+.lang-options {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--spacing-xs));
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  list-style: none;
+  padding: var(--spacing-xs) 0;
+  margin: 0;
+  box-shadow: var(--shadow-base);
+  display: none;
+  z-index: 1000;
+}
+
+.lang-options.open {
+  display: block;
+}
+
+.lang-options li {
+  padding: var(--spacing-xs) var(--spacing-md);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.lang-options li:hover,
+.lang-options li[aria-selected="true"] {
+  background-color: var(--color-accent-50);
 }
 
 .nav-toggle {
@@ -303,24 +349,31 @@ a:focus {
 
   .nav-menu {
     position: fixed;
-    top: var(--header-height);
-    left: 0;
+    top: 0;
     right: 0;
+    bottom: 0;
+    width: 70vw;
+    max-width: 280px;
     background-color: var(--color-surface);
-    border-bottom: 1px solid var(--color-border);
+    border-left: 1px solid var(--color-border);
     flex-direction: column;
-    padding: var(--spacing-lg);
+    padding: calc(var(--header-height) + var(--spacing-lg)) var(--spacing-lg)
+      var(--spacing-lg);
     gap: var(--spacing-lg);
-    transform: translateY(-100%);
+    transform: translateX(100%);
     opacity: 0;
     visibility: hidden;
-    transition: all var(--transition-base);
+    transition: transform var(--transition-base), opacity var(--transition-base);
   }
 
   .nav-menu.active {
-    transform: translateY(0);
+    transform: translateX(0);
     opacity: 1;
     visibility: visible;
+  }
+
+  .nav-menu .nav-link {
+    padding: var(--spacing-md) 0;
   }
 
   .nav-toggle {

--- a/culttech.html
+++ b/culttech.html
@@ -18,7 +18,7 @@
             <div class="nav-container">
                 <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
 
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -27,10 +27,19 @@
                 </ul>
 
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
             <div class="nav-container">
                 <a href="#" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
                 
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link active" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -25,10 +25,19 @@
                 </ul>
 
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>

--- a/js/main.js
+++ b/js/main.js
@@ -85,6 +85,7 @@ class PortfolioApp {
     const navMenu = document.getElementById("nav-menu")
 
     navMenu.classList.add("active")
+    navMenu.setAttribute("aria-hidden", "false")
     navToggle.classList.add("active")
     navToggle.setAttribute("aria-expanded", "true")
 
@@ -97,6 +98,7 @@ class PortfolioApp {
     const navMenu = document.getElementById("nav-menu")
 
     navMenu.classList.remove("active")
+    navMenu.setAttribute("aria-hidden", "true")
     navToggle.classList.remove("active")
     navToggle.setAttribute("aria-expanded", "false")
 
@@ -106,18 +108,34 @@ class PortfolioApp {
 
   setupLanguageToggle() {
     const langToggle = document.getElementById("lang-toggle")
+    const langOptions = document.getElementById("lang-options")
 
-    if (langToggle) {
-      langToggle.addEventListener("click", () => {
-        this.toggleLanguage()
+    if (langToggle && langOptions) {
+      langToggle.addEventListener("click", (e) => {
+        e.stopPropagation()
+        const expanded = langToggle.getAttribute("aria-expanded") === "true"
+        langToggle.setAttribute("aria-expanded", expanded ? "false" : "true")
+        langOptions.classList.toggle("open", !expanded)
+      })
+
+      langOptions.querySelectorAll("[data-lang]").forEach((option) => {
+        option.addEventListener("click", () => {
+          const lang = option.getAttribute("data-lang")
+          this.currentLang = lang
+          this.updateLanguage()
+          this.saveLanguagePreference()
+          langOptions.classList.remove("open")
+          langToggle.setAttribute("aria-expanded", "false")
+        })
+      })
+
+      document.addEventListener("click", (e) => {
+        if (!langToggle.contains(e.target) && !langOptions.contains(e.target)) {
+          langOptions.classList.remove("open")
+          langToggle.setAttribute("aria-expanded", "false")
+        }
       })
     }
-  }
-
-  toggleLanguage() {
-    this.currentLang = this.currentLang === "ru" ? "en" : "ru"
-    this.updateLanguage()
-    this.saveLanguagePreference()
   }
 
   updateLanguage() {
@@ -141,6 +159,14 @@ class PortfolioApp {
       if (langCurrent) {
         langCurrent.textContent = this.currentLang.toUpperCase()
       }
+    }
+
+    const langOptions = document.getElementById("lang-options")
+    if (langOptions) {
+      langOptions.querySelectorAll("[data-lang]").forEach((opt) => {
+        const selected = opt.getAttribute("data-lang") === this.currentLang
+        opt.setAttribute("aria-selected", selected ? "true" : "false")
+      })
     }
 
     // Update document language

--- a/post.html
+++ b/post.html
@@ -17,7 +17,7 @@
         <nav class="nav" role="navigation" aria-label="Основная навигация">
             <div class="nav-container">
                 <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link active" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -25,10 +25,19 @@
                     <li><a href="contacts.html" class="nav-link" data-ru="Контакты" data-en="Contacts">Контакты</a></li>
                 </ul>
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>

--- a/roadmap.html
+++ b/roadmap.html
@@ -18,7 +18,7 @@
             <div class="nav-container">
                 <a href="index.html" class="logo" aria-label="На главную">Еремей Дмитриенко</a>
 
-                <ul class="nav-menu" id="nav-menu">
+                <ul class="nav-menu" id="nav-menu" aria-hidden="true">
                     <li><a href="index.html" class="nav-link" data-ru="Главная" data-en="Home">Главная</a></li>
                     <li><a href="blog.html" class="nav-link" data-ru="Блог" data-en="Blog">Блог</a></li>
                     <li><a href="roadmap.html" class="nav-link active" data-ru="Путь" data-en="Path">Путь</a></li>
@@ -27,10 +27,19 @@
                 </ul>
 
                 <div class="nav-controls">
-                    <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык">
-                        <span class="lang-current">RU</span>
-                    </button>
-                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
+                    <div class="language-selector">
+                        <button class="lang-toggle" id="lang-toggle" aria-label="Переключить язык" aria-haspopup="listbox" aria-controls="lang-options" aria-expanded="false">
+                            <svg class="lang-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16zm3.46-12h2.08a8.05 8.05 0 00-2.5-2.5c.22.75.36 1.6.42 2.5zm-3.46-2c-.8 0-1.54.9-2.05 2h4.1c-.5-1.1-1.25-2-2.05-2zm-3.54.5a8.05 8.05 0 00-2.5 2.5h2.08c.06-.9.2-1.75.42-2.5zM6.5 12c0-.7.05-1.37.15-2H4.6a8.06 8.06 0 000 4h2.05A13.5 13.5 0 016.5 12zm.46 3.5H4.88a8.05 8.05 0 002.5 2.5c-.22-.75-.36-1.6-.42-2.5zm3.54 2c.8 0 1.55-.9 2.05-2h-4.1c.5 1.1 1.25 2 2.05 2zm3.54-.5a8.05 8.05 0 002.5-2.5h-2.08c-.06.9-.2 1.75-.42 2.5zM17.5 12c0 .7-.05 1.37-.15 2h2.05a8.06 8.06 0 000-4h-2.05c.1.63.15 1.3.15 2z"/>
+                            </svg>
+                            <span class="lang-current">RU</span>
+                        </button>
+                        <ul class="lang-options" id="lang-options" role="listbox" aria-label="Выбор языка">
+                            <li data-lang="ru" role="option" aria-selected="true">RU</li>
+                            <li data-lang="en" role="option" aria-selected="false">EN</li>
+                        </ul>
+                    </div>
+                    <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
                         <span></span>
                         <span></span>
                         <span></span>


### PR DESCRIPTION
## Summary
- align logo and menu spacing
- highlight active page with a background
- convert language toggle to dropdown with a globe icon
- move mobile menu to a slide-in side panel
- update JS to handle new dropdown and accessibility states

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849a4d2e5c8832cbcc0f0f11640160f