### PR TITLE
Improve mobile navigation menu overlay

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -89,6 +89,8 @@
   border: none;
   padding: var(--spacing-xs);
   cursor: pointer;
+  position: relative;
+  z-index: 1001;
 }
 .nav-toggle span {
   width: 20px;
@@ -99,13 +101,9 @@
 @media (max-width: 768px) {
   .nav-menu {
     position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: 70vw;
-    max-width: 280px;
+    inset: 0;
+    width: 100vw;
     background: var(--color-surface);
-    border-left: 1px solid var(--color-border);
     flex-direction: column;
     padding: calc(var(--header-height) + var(--spacing-lg)) var(--spacing-lg);
     gap: var(--spacing-lg);
@@ -113,6 +111,7 @@
     opacity: 0;
     visibility: hidden;
     transition: transform var(--transition-base), opacity var(--transition-base);
+    z-index: 1000;
   }
   .nav-menu.active {
     transform: translateX(0);

--- a/js/main.js
+++ b/js/main.js
@@ -205,7 +205,7 @@ class PortfolioApp {
   }
 
   scrollToElement(element) {
-    const headerHeight = document.querySelector(".header").offsetHeight
+    const headerHeight = document.querySelector(".navbar").offsetHeight
     const elementPosition = element.offsetTop - headerHeight - 20
 
     window.scrollTo({
@@ -244,7 +244,7 @@ class PortfolioApp {
   }
 
   handleScroll() {
-    const header = document.querySelector(".header")
+    const header = document.querySelector(".navbar")
     const scrollY = window.scrollY
 
     // Add/remove scrolled class to header
@@ -388,7 +388,7 @@ const animationStyles = `
         }
     }
     
-    .header.scrolled {
+    .navbar.scrolled {
         box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
     }
 `


### PR DESCRIPTION
## Summary
- ensure the menu covers the entire viewport on small screens
- keep the toggle button accessible above the menu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ae3e8fb8832ca0e6ff10b83dac22