### PR TITLE
Fix language toggle on titles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -150,6 +150,8 @@ class PortfolioApp {
         element.placeholder = text
       } else if (element.tagName === "TITLE") {
         document.title = text
+        // also update the actual <title> element text for consistency
+        element.textContent = text
       } else {
         element.textContent = text
       }


### PR DESCRIPTION
## Summary
- ensure that switching language updates the `<title>` text as well

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849c16441c8832c8880bf616caad456