### PR TITLE
Fix language titles

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Блог - Еремей Дмитриенко</title>
+    <title data-ru="Блог - Еремей Дмитриенко" data-en="Blog - Eremei Dmitrienko">Блог - Еремей Дмитриенко</title>
     <meta name="description" content="Статьи о культуре, технологиях и предпринимательстве">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/navigation.css">

--- a/contacts.html
+++ b/contacts.html
@@ -77,10 +77,10 @@
         <section class="hero-section" aria-labelledby="hero-title">
             <div class="container">
                 <div class="hero-content">
-                    <h1 id="hero-title" class="hero-title" data-en="Let's Connect">
+                    <h1 id="hero-title" class="hero-title" data-ru="Давайте знакомиться" data-en="Let's Connect">
                         Давайте знакомиться
                     </h1>
-                    <p class="hero-subtitle" data-en="Ready to collaborate, discuss ideas, or just have an interesting conversation about culture, technology, and entrepreneurship.">
+                    <p class="hero-subtitle" data-ru="Готов к сотрудничеству, обсуждению идей или просто интересному разговору о культуре, технологиях и предпринимательстве." data-en="Ready to collaborate, discuss ideas, or just have an interesting conversation about culture, technology, and entrepreneurship.">
                         Готов к сотрудничеству, обсуждению идей или просто интересному разговору о культуре, технологиях и предпринимательстве.
                     </p>
                 </div>

--- a/culttech.html
+++ b/culttech.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CultTech Hub - Еремей Дмитриенко</title>
+    <title data-ru="CultTech Hub - Еремей Дмитриенко" data-en="CultTech Hub - Eremei Dmitrienko">CultTech Hub - Еремей Дмитриенко</title>
     <meta name="description" content="Интерактивная платформа для нетворкинга на пересечении культуры, технологий и предпринимательства">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/navigation.css">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Дмитриёнок | Дорогу осилит идущий</title>
+    <title data-ru="Дмитриёнок | Дорогу осилит идущий" data-en="Dmitrienok | The road is mastered by walking">Дмитриёнок | Дорогу осилит идущий</title>
     <meta name="description" content="Персональный сайт-портфолио студента Еремея">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/navigation.css">

--- a/js/main.js
+++ b/js/main.js
@@ -150,6 +150,8 @@ class PortfolioApp {
         element.placeholder = text
       } else if (element.tagName === "TITLE") {
         document.title = text
+        // also update the actual <title> element text for consistency
+        element.textContent = text
       } else {
         element.textContent = text
       }

--- a/post.html
+++ b/post.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Пост - Еремей Дмитриенко</title>
+    <title data-ru="Пост - Еремей Дмитриенко" data-en="Post - Eremei Dmitrienko">Пост - Еремей Дмитриенко</title>
     <meta name="description" content="Запись блога">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/navigation.css">

--- a/roadmap.html
+++ b/roadmap.html
@@ -49,8 +49,8 @@
         <section class="roadmap-hero">
             <div class="container">
                 <div class="hero-content">
-                    <h1 class="hero-title" data-en="Life Roadmap">Жизненный путь</h1>
-                    <p class="hero-subtitle" data-en="My journey through life, education, and personal growth">
+                    <h1 class="hero-title" data-ru="Жизненный путь" data-en="Life Roadmap">Жизненный путь</h1>
+                    <p class="hero-subtitle" data-ru="Мой путь через жизнь, образование и личностный рост" data-en="My journey through life, education, and personal growth">
                         Мой путь через жизнь, образование и личностный рост
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- add data-ru and data-en to `<title>` tags so all pages switch language
- include translation attributes on hero titles for Roadmap and Contacts pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c16441c8832c8880bf616caad456