### PR TITLE
Fix contacts page translations

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -39,7 +39,7 @@
 </head>
 <body>
     <!-- Skip to main content -->
-    <a href="#main" class="skip-link" data-en="Skip to main content">Перейти к основному содержанию</a>
+    <a href="#main" class="skip-link" data-ru="Перейти к основному содержанию" data-en="Skip to main content">Перейти к основному содержанию</a>
     
     <!-- Header -->
 <header class="navbar" role="banner">
@@ -91,49 +91,49 @@
         <!-- Contact Methods -->
         <section class="contact-methods" aria-labelledby="methods-title">
             <div class="container">
-                <h2 id="methods-title" class="section-title" data-en="How to Reach Me">
+                <h2 id="methods-title" class="section-title" data-ru="Как со мной связаться" data-en="How to Reach Me">
                     Как со мной связаться
                 </h2>
                 
                 <div class="methods-grid">
                     <div class="method-card" data-method="email">
                         <div class="method-icon">📧</div>
-                        <h3 class="method-title" data-en="Email">Электронная почта</h3>
-                        <p class="method-description" data-en="For business inquiries and detailed discussions">
+                        <h3 class="method-title" data-ru="Электронная почта" data-en="Email">Электронная почта</h3>
+                        <p class="method-description" data-ru="Для деловых предложений и подробных обсуждений" data-en="For business inquiries and detailed discussions">
                             Для деловых предложений и подробных обсуждений
                         </p>
                         <a href="mailto:eremeidmitrienko@ya.ru" class="method-link">
                             eremeidmitrienko@ya.ru
                         </a>
-                        <div class="method-response" data-en="Response within 24 hours">
+                        <div class="method-response" data-ru="Отвечу в течение 24 часов" data-en="Response within 24 hours">
                             Отвечу в течение 24 часов
                         </div>
                     </div>
 
                     <div class="method-card" data-method="telegram">
                         <div class="method-icon">💬</div>
-                        <h3 class="method-title" data-en="Telegram">Телеграм</h3>
-                        <p class="method-description" data-en="For quick questions and informal communication">
+                        <h3 class="method-title" data-ru="Телеграм" data-en="Telegram">Телеграм</h3>
+                        <p class="method-description" data-ru="Для быстрых вопросов и неформального общения" data-en="For quick questions and informal communication">
                             Для быстрых вопросов и неформального общения
                         </p>
                         <a href="https://t.me/Eremei_Dmitrienko" class="method-link" target="_blank" rel="noopener">
                             t.me/Eremei_Dmitrienko
                         </a>
-                        <div class="method-response" data-en="Usually online during the day">
+                        <div class="method-response" data-ru="Обычно онлайн в течение дня" data-en="Usually online during the day">
                             Обычно онлайн в течение дня
                         </div>
                     </div>
 
                     <div class="method-card" data-method="vk">
                         <div class="method-icon">📱</div>
-                        <h3 class="method-title" data-en="VK">VK</h3>
-                        <p class="method-description" data-en="Social network profile">
+                        <h3 class="method-title" data-ru="VK" data-en="VK">VK</h3>
+                        <p class="method-description" data-ru="Страница в VK" data-en="Social network profile">
                             Страница в VK
                         </p>
                         <a href="https://vk.com/dm1trienko" class="method-link" target="_blank" rel="noopener">
                             vk.com/dm1trienko
                         </a>
-                        <div class="method-response" data-en="Available there">
+                        <div class="method-response" data-ru="Отвечаю там регулярно" data-en="Available there">
                             Отвечаю там регулярно
                         </div>
                     </div>
@@ -143,7 +143,7 @@
 
         <section class="donate-section" aria-labelledby="donate-title">
             <div class="container">
-                <h2 id="donate-title" class="section-title" data-en="Support">
+                <h2 id="donate-title" class="section-title" data-ru="Поддержать проект" data-en="Support">
                     Поддержать проект
                 </h2>
                 <div class="donate-grid">
@@ -164,10 +164,10 @@
             <div class="container">
                 <div class="form-wrapper">
                     <div class="form-header">
-                        <h2 id="form-title" class="section-title" data-en="Send a Message">
+                        <h2 id="form-title" class="section-title" data-ru="Отправить сообщение" data-en="Send a Message">
                             Отправить сообщение
                         </h2>
-                        <p class="form-description" data-en="Fill out the form below and I'll get back to you as soon as possible.">
+                        <p class="form-description" data-ru="Заполните форму ниже, и я свяжусь с вами как можно скорее." data-en="Fill out the form below and I'll get back to you as soon as possible.">
                             Заполните форму ниже, и я свяжусь с вами как можно скорее.
                         </p>
                     </div>
@@ -175,7 +175,7 @@
                     <form class="contact-form" id="contactForm" novalidate>
                         <div class="form-row">
                             <div class="form-group">
-                                <label for="name" class="form-label" data-en="Name *">Имя *</label>
+                                <label for="name" class="form-label" data-ru="Имя *" data-en="Name *">Имя *</label>
                                 <input 
                                     type="text" 
                                     id="name" 
@@ -183,14 +183,15 @@
                                     class="form-input" 
                                     required 
                                     aria-describedby="name-error"
-                                    data-en-placeholder="Your name"
+                                    data-ru="Ваше имя"
+                                    data-en="Your name"
                                     placeholder="Ваше имя"
                                 >
                                 <div class="form-error" id="name-error" role="alert"></div>
                             </div>
 
                             <div class="form-group">
-                                <label for="email" class="form-label" data-en="Email *">Email *</label>
+                                <label for="email" class="form-label" data-ru="Email *" data-en="Email *">Email *</label>
                                 <input 
                                     type="email" 
                                     id="email" 
@@ -198,7 +199,8 @@
                                     class="form-input" 
                                     required 
                                     aria-describedby="email-error"
-                                    data-en-placeholder="your@email.com"
+                                    data-ru="ваш@email.com"
+                                    data-en="your@email.com"
                                     placeholder="ваш@email.com"
                                 >
                                 <div class="form-error" id="email-error" role="alert"></div>
@@ -206,20 +208,20 @@
                         </div>
 
                         <div class="form-group">
-                            <label for="subject" class="form-label" data-en="Subject *">Тема *</label>
+                            <label for="subject" class="form-label" data-ru="Тема *" data-en="Subject *">Тема *</label>
                             <select id="subject" name="subject" class="form-select" required aria-describedby="subject-error">
-                                <option value="" data-en="Select a topic">Выберите тему</option>
-                                <option value="collaboration" data-en="Collaboration">Сотрудничество</option>
-                                <option value="consultation" data-en="Consultation">Консультация</option>
-                                <option value="project" data-en="Project Discussion">Обсуждение проекта</option>
-                                <option value="networking" data-en="Networking">Нетворкинг</option>
-                                <option value="other" data-en="Other">Другое</option>
+                                <option value="" data-ru="Выберите тему" data-en="Select a topic">Выберите тему</option>
+                                <option value="collaboration" data-ru="Сотрудничество" data-en="Collaboration">Сотрудничество</option>
+                                <option value="consultation" data-ru="Консультация" data-en="Consultation">Консультация</option>
+                                <option value="project" data-ru="Обсуждение проекта" data-en="Project Discussion">Обсуждение проекта</option>
+                                <option value="networking" data-ru="Нетворкинг" data-en="Networking">Нетворкинг</option>
+                                <option value="other" data-ru="Другое" data-en="Other">Другое</option>
                             </select>
                             <div class="form-error" id="subject-error" role="alert"></div>
                         </div>
 
                         <div class="form-group">
-                            <label for="message" class="form-label" data-en="Message *">Сообщение *</label>
+                            <label for="message" class="form-label" data-ru="Сообщение *" data-en="Message *">Сообщение *</label>
                             <textarea 
                                 id="message" 
                                 name="message" 
@@ -227,7 +229,8 @@
                                 rows="6" 
                                 required 
                                 aria-describedby="message-error"
-                                data-en-placeholder="Tell me about your idea, project, or question..."
+                                data-ru="Расскажите о вашей идее, проекте или вопросе..."
+                                data-en="Tell me about your idea, project, or question..."
                                 placeholder="Расскажите о вашей идее, проекте или вопросе..."
                             ></textarea>
                             <div class="form-error" id="message-error" role="alert"></div>
@@ -240,7 +243,7 @@
                             <label class="checkbox-label">
                                 <input type="checkbox" id="privacy" name="privacy" required class="checkbox-input">
                                 <span class="checkbox-custom"></span>
-                                <span class="checkbox-text" data-en="I agree to the processing of personal data">
+                                <span class="checkbox-text" data-ru="Согласен на обработку персональных данных" data-en="I agree to the processing of personal data">
                                     Согласен на обработку персональных данных
                                 </span>
                             </label>
@@ -248,13 +251,13 @@
                         </div>
 
                         <button type="submit" class="form-submit" id="submitBtn">
-                            <span class="submit-text" data-en="Send Message">Отправить сообщение</span>
-                            <span class="submit-loading" data-en="Sending...">Отправляю...</span>
+                            <span class="submit-text" data-ru="Отправить сообщение" data-en="Send Message">Отправить сообщение</span>
+                            <span class="submit-loading" data-ru="Отправляю..." data-en="Sending...">Отправляю...</span>
                         </button>
 
                         <div class="form-success" id="formSuccess" role="alert">
                             <div class="success-icon">✅</div>
-                            <div class="success-text" data-en="Message sent successfully! I'll get back to you soon.">
+                            <div class="success-text" data-ru="Сообщение успешно отправлено! Скоро свяжусь с вами." data-en="Message sent successfully! I'll get back to you soon.">
                                 Сообщение успешно отправлено! Скоро свяжусь с вами.
                             </div>
                         </div>
@@ -266,50 +269,50 @@
         <!-- FAQ Section -->
         <section class="faq-section" aria-labelledby="faq-title">
             <div class="container">
-                <h2 id="faq-title" class="section-title" data-en="Frequently Asked Questions">
+                <h2 id="faq-title" class="section-title" data-ru="Часто задаваемые вопросы" data-en="Frequently Asked Questions">
                     Часто задаваемые вопросы
                 </h2>
 
                 <div class="faq-list">
                     <div class="faq-item">
-                        <button class="faq-question" aria-expanded="false" data-en="What projects are you currently working on?">
+                        <button class="faq-question" aria-expanded="false" data-ru="Над какими проектами вы сейчас работаете?" data-en="What projects are you currently working on?">
                             Над какими проектами вы сейчас работаете?
                         </button>
                         <div class="faq-answer">
-                            <p data-en="I'm currently focused on several areas: developing web applications using modern technologies, exploring the intersection of culture and technology, and working on entrepreneurial projects in the creative industries.">
+                            <p data-ru="Сейчас я сосредоточен на нескольких направлениях: разработка веб-приложений с использованием современных технологий, исследование пересечения культуры и технологий, а также работа над предпринимательскими проектами в креативных индустриях." data-en="I'm currently focused on several areas: developing web applications using modern technologies, exploring the intersection of culture and technology, and working on entrepreneurial projects in the creative industries.">
                                 Сейчас я сосредоточен на нескольких направлениях: разработка веб-приложений с использованием современных технологий, исследование пересечения культуры и технологий, а также работа над предпринимательскими проектами в креативных индустриях.
                             </p>
                         </div>
                     </div>
 
                     <div class="faq-item">
-                        <button class="faq-question" aria-expanded="false" data-en="Are you available for freelance work?">
+                        <button class="faq-question" aria-expanded="false" data-ru="Доступны ли вы для фриланс-работы?" data-en="Are you available for freelance work?">
                             Доступны ли вы для фриланс-работы?
                         </button>
                         <div class="faq-answer">
-                            <p data-en="Yes, I'm open to interesting freelance projects, especially those that combine technology with culture or have an innovative approach. Feel free to reach out with your project details.">
+                            <p data-ru="Да, я открыт для интересных фриланс-проектов, особенно тех, которые сочетают технологии с культурой или имеют инновационный подход. Не стесняйтесь обращаться с деталями вашего проекта." data-en="Yes, I'm open to interesting freelance projects, especially those that combine technology with culture or have an innovative approach. Feel free to reach out with your project details.">
                                 Да, я открыт для интересных фриланс-проектов, особенно тех, которые сочетают технологии с культурой или имеют инновационный подход. Не стесняйтесь обращаться с деталями вашего проекта.
                             </p>
                         </div>
                     </div>
 
                     <div class="faq-item">
-                        <button class="faq-question" aria-expanded="false" data-en="Do you offer mentoring or consultations?">
+                        <button class="faq-question" aria-expanded="false" data-ru="Предлагаете ли вы менторство или консультации?" data-en="Do you offer mentoring or consultations?">
                             Предлагаете ли вы менторство или консультации?
                         </button>
                         <div class="faq-answer">
-                            <p data-en="I'm happy to share my experience with students and young professionals interested in the intersection of technology, culture, and entrepreneurship. Contact me to discuss the format and topics.">
+                            <p data-ru="Я с удовольствием делюсь опытом со студентами и молодыми специалистами, интересующимися пересечением технологий, культуры и предпринимательства. Свяжитесь со мной, чтобы обсудить формат и темы." data-en="I'm happy to share my experience with students and young professionals interested in the intersection of technology, culture, and entrepreneurship. Contact me to discuss the format and topics.">
                                 Я с удовольствием делюсь опытом со студентами и молодыми специалистами, интересующимися пересечением технологий, культуры и предпринимательства. Свяжитесь со мной, чтобы обсудить формат и темы.
                             </p>
                         </div>
                     </div>
 
                     <div class="faq-item">
-                        <button class="faq-question" aria-expanded="false" data-en="How quickly do you respond to messages?">
+                        <button class="faq-question" aria-expanded="false" data-ru="Как быстро вы отвечаете на сообщения?" data-en="How quickly do you respond to messages?">
                             Как быстро вы отвечаете на сообщения?
                         </button>
                         <div class="faq-answer">
-                            <p data-en="I try to respond to all messages within 24 hours. For urgent matters, Telegram is the fastest way to reach me. Complex questions may require more time for a thoughtful response.">
+                            <p data-ru="Стараюсь отвечать на все сообщения в течение 24 часов. Для срочных вопросов Telegram — самый быстрый способ связаться со мной. Сложные вопросы могут потребовать больше времени для обдуманного ответа." data-en="I try to respond to all messages within 24 hours. For urgent matters, Telegram is the fastest way to reach me. Complex questions may require more time for a thoughtful response.">
                                 Стараюсь отвечать на все сообщения в течение 24 часов. Для срочных вопросов Telegram — самый быстрый способ связаться со мной. Сложные вопросы могут потребовать больше времени для обдуманного ответа.
                             </p>
                         </div>
@@ -322,18 +325,18 @@
         <section class="cta-section">
             <div class="container">
                 <div class="cta-content">
-                    <h2 class="cta-title" data-en="Ready to Start a Conversation?">
+                    <h2 class="cta-title" data-ru="Готовы начать разговор?" data-en="Ready to Start a Conversation?">
                         Готовы начать разговор?
                     </h2>
-                    <p class="cta-description" data-en="Whether you have a project idea, want to collaborate, or just want to chat about the future of culture and technology — I'd love to hear from you.">
+                    <p class="cta-description" data-ru="Есть ли у вас идея проекта, желание сотрудничать или просто поговорить о будущем культуры и технологий — буду рад услышать от вас." data-en="Whether you have a project idea, want to collaborate, or just want to chat about the future of culture and technology — I'd love to hear from you.">
                         Есть ли у вас идея проекта, желание сотрудничать или просто поговорить о будущем культуры и технологий — буду рад услышать от вас.
                     </p>
                     <div class="cta-buttons">
                         <a href="mailto:eremeidmitrienko@ya.ru" class="btn btn-primary">
-                            <span data-en="Send Email">Написать Email</span>
+                            <span data-ru="Написать Email" data-en="Send Email">Написать Email</span>
                         </a>
                         <a href="https://t.me/Eremei_Dmitrienko" class="btn btn-secondary" target="_blank" rel="noopener">
-                            <span data-en="Message on Telegram">Написать в Telegram</span>
+                            <span data-ru="Написать в Telegram" data-en="Message on Telegram">Написать в Telegram</span>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add missing `data-ru` attributes to `contacts.html`
- ensure placeholders and FAQ sections translate correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c95347d0832cb4f968659502d92a