### PR TITLE
Fix duplicate post titles

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -49,15 +49,36 @@ class BlogPage {
     if (match) {
       match[1].split(/\n/).forEach((line) => {
         const [k, ...r] = line.split(':')
-        meta[k.trim()] = r.join(':').trim()
+        let val = r.join(':').trim()
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1)
+        }
+        meta[k.trim()] = val
       })
       body = md.slice(match[0].length)
     }
+    body = this.stripTitleFromContent(body, meta.title)
     const excerpt = body
       .trim()
       .split(/\n{2,}/)[0]
       .replace(/[#*_`>\[\]]/g, '')
     return { meta, excerpt, content: body }
+  }
+
+  stripTitleFromContent(content, title) {
+    if (!title) return content
+    const lines = content.split(/\n/)
+    if (lines[0] && /^#\s+/.test(lines[0])) {
+      const heading = lines[0].replace(/^#\s+/, '').trim()
+      if (heading === title) {
+        lines.shift()
+        if (lines[0] && lines[0].trim() === '') lines.shift()
+      }
+    }
+    return lines.join('\n')
   }
 
   renderCard(post) {

--- a/js/post.js
+++ b/js/post.js
@@ -13,6 +13,7 @@ class BlogPostPage {
       }
       const text = await res.text()
       const { meta, content } = this.parseFrontmatter(text)
+      const body = this.stripTitleFromContent(content, meta.title)
 
       if (meta.title) {
         document.getElementById('post-title').textContent = meta.title
@@ -25,7 +26,7 @@ class BlogPostPage {
         dateEl.textContent = this.formatDate(meta.date)
       }
 
-      document.getElementById('post-content').innerHTML = marked.parse(content)
+      document.getElementById('post-content').innerHTML = marked.parse(body)
     } catch (e) {
       const msg = e && e.message ? e.message : 'Unknown error'
       document.getElementById('post-content').textContent =
@@ -40,11 +41,31 @@ class BlogPostPage {
     if (match) {
       match[1].split(/\n/).forEach((line) => {
         const [k, ...r] = line.split(':')
-        meta[k.trim()] = r.join(':').trim()
+        let val = r.join(':').trim()
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1)
+        }
+        meta[k.trim()] = val
       })
       body = md.slice(match[0].length)
     }
     return { meta, content: body }
+  }
+
+  stripTitleFromContent(content, title) {
+    if (!title) return content
+    const lines = content.split(/\n/)
+    if (lines[0] && /^#\s+/.test(lines[0])) {
+      const heading = lines[0].replace(/^#\s+/, '').trim()
+      if (heading === title) {
+        lines.shift()
+        if (lines[0] && lines[0].trim() === '') lines.shift()
+      }
+    }
+    return lines.join('\n')
   }
 
   formatDate(str) {


### PR DESCRIPTION
## Summary
- strip surrounding quotes from post metadata
- remove first heading from markdown if it matches the title

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849e0a7db78832c8e1d6512ff9b1c7b