### PR TITLE
Fix duplicate title on post page

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -71,11 +71,14 @@ class BlogPage {
   stripTitleFromContent(content, title) {
     if (!title) return content
     const lines = content.split(/\n/)
+    while (lines.length && lines[0].trim() === '') {
+      lines.shift()
+    }
     if (lines[0] && /^#\s+/.test(lines[0])) {
       const heading = lines[0].replace(/^#\s+/, '').trim()
       if (heading === title) {
         lines.shift()
-        if (lines[0] && lines[0].trim() === '') lines.shift()
+        if (lines.length && lines[0].trim() === '') lines.shift()
       }
     }
     return lines.join('\n')

--- a/js/post.js
+++ b/js/post.js
@@ -58,14 +58,14 @@ class BlogPostPage {
   stripTitleFromContent(content, title) {
     if (!title) return content
     const lines = content.split(/\n/)
-    while (lines[0] && lines[0].trim() === '') {
+    while (lines.length && lines[0].trim() === '') {
       lines.shift()
     }
     if (lines[0] && /^#\s+/.test(lines[0])) {
       const heading = lines[0].replace(/^#\s+/, '').trim()
       if (heading === title) {
         lines.shift()
-        while (lines[0] && lines[0].trim() === '') lines.shift()
+        while (lines.length && lines[0].trim() === '') lines.shift()
       }
     }
     return lines.join('\n')


### PR DESCRIPTION
## Summary
- strip leading blank lines in `stripTitleFromContent`
- apply fix for both blog and post pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849ea16e070832c9293d9af0e29243c