### PR TITLE
Improve dark theme text contrast

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -92,8 +92,8 @@
     --color-surface: #3b3835;
     --color-border: #4a4744;
     --color-text-primary: #eae5de;
-    --color-text-secondary: #b8aea3;
-    --color-text-muted: #93897c;
+    --color-text-secondary: #dcd2c7;
+    --color-text-muted: #c0b9b0;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak dark mode colors so text is brighter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f73e86f8832c82d9e676b60a28aa