### PR TITLE
Fix dark theme navbar background

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -4,7 +4,7 @@
   top: 0;
   left: 0;
   right: 0;
-  background: rgba(254, 254, 254, 0.95);
+  background: var(--navbar-background);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--color-border);
   height: var(--header-height);

--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,7 @@
   --color-accent: #bfa181;
   --color-background: #f5f2ed;
   --color-surface: #ffffff;
+  --navbar-background: rgba(255, 255, 255, 0.95);
   --color-border: #d6cec3;
   --color-text-primary: #362f2d;
   --color-text-secondary: #5c544d;
@@ -91,6 +92,7 @@
     --color-accent-dark: #c19c77;
     --color-background: #2b2927;
     --color-surface: #3b3835;
+    --navbar-background: rgba(59, 56, 53, 0.95);
     --color-border: #4a4744;
     --color-text-primary: #eae5de;
     --color-text-secondary: #e8e0d7;


### PR DESCRIPTION
## Summary
- add `--navbar-background` custom property for navbar coloring
- use the variable in `navigation.css`
- set dark theme value for `--navbar-background`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849fb187e00832cb07feda0a5b43116