### PR TITLE
Improve active states in dark theme

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -446,6 +446,11 @@
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
 }
 
+.btn-primary:active {
+  background: var(--color-stone-100);
+  color: var(--color-amber-600);
+}
+
 .btn-secondary {
   background: transparent;
   color: white;
@@ -456,6 +461,11 @@
   background: white;
   color: var(--color-amber-600);
   transform: translateY(-2px);
+}
+
+.btn-secondary:active {
+  background: var(--color-stone-50);
+  color: var(--color-amber-600);
 }
 
 /* Animations */

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,10 @@
   --color-text-muted: #877f77;
   --color-text: var(--color-text-primary);
 
+  /* System color schemes */
+  color-scheme: light;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
+
   /* Extended palette */
   --color-primary-50: #e9e5e1;
   --color-primary-100: #d6cfc9;
@@ -96,7 +100,10 @@
     --color-border: #4a4744;
     --color-text-primary: #eae5de;
     --color-text-secondary: #e8e0d7;
-    --color-text-muted: #d0c6bd;
+  --color-text-muted: #d0c6bd;
+
+    color-scheme: dark;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0.1);
   }
 }
 
@@ -469,6 +476,11 @@ a:focus {
   box-shadow: var(--shadow-lg);
 }
 
+.btn-primary:active {
+  background-color: var(--color-accent);
+  color: var(--color-background);
+}
+
 .btn-secondary {
   background-color: transparent;
   color: var(--color-primary);
@@ -480,6 +492,12 @@ a:focus {
   border-color: var(--color-accent);
   transform: translateY(-1px);
   box-shadow: var(--shadow-base);
+}
+
+.btn-secondary:active {
+  background-color: var(--color-surface);
+  border-color: var(--color-accent-dark);
+  color: var(--color-primary);
 }
 
 /* Sections */


### PR DESCRIPTION
## Summary
- improve system color schemes for light/dark modes
- tweak active styles for buttons
- add active button styles on contacts page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849fc77e2e4832cb1c79df461beeeee