### PR TITLE
Fix dark mode tap highlight and donate section

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -575,6 +575,15 @@
   .faq-answer p {
     color: var(--color-stone-300);
   }
+
+  .donate-section {
+    background: var(--color-stone-800);
+  }
+
+  .donate-section p,
+  .donate-section code {
+    color: var(--color-stone-100);
+  }
 }
 
 /* Responsive Design */

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -135,3 +135,16 @@
     transform: rotate(-45deg) translate(7px, -6px);
   }
 }
+
+/* Active state for navigation links */
+.nav-link:active {
+  background-color: var(--color-accent-50);
+  color: var(--color-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .nav-link:active {
+    background-color: var(--color-stone-800);
+    color: var(--color-primary);
+  }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -103,7 +103,7 @@
   --color-text-muted: #d0c6bd;
 
     color-scheme: dark;
-    -webkit-tap-highlight-color: rgba(255, 255, 255, 0.1);
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0.05);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust dark theme tap highlight color
- add active state styling for navigation links
- darken donate section background in dark mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849fec17324832c929818261ff7ab5a