### PR TITLE
Fix donate section dark theme

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -702,3 +702,10 @@
   width: 160px;
   height: 160px;
 }
+
+/* Dark theme override for donate section */
+@media (prefers-color-scheme: dark) {
+  .donate-section {
+    background: var(--color-stone-900);
+  }
+}


### PR DESCRIPTION
## Summary
- darken background for donate section in contacts page when using dark mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a013429dc832ca6138bdcc4062564