### PR TITLE
Fix contact page scrolling and add copy buttons

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -149,11 +149,13 @@
                 <div class="donate-grid">
                     <div class="donate-item">
                         <img src="img/ton_qr.png" alt="TON QR">
-                        <p>TON: <code>UQCb53PoQTmyikWaQwyhplh5ogfpmJCa2w6KRSNZcy56fhOm</code></p>
+                        <button class="btn btn-primary copy-address" data-address="UQCb53PoQTmyikWaQwyhplh5ogfpmJCa2w6KRSNZcy56fhOm" data-ru="Скопировать TON" data-en="Copy TON">Скопировать TON</button>
+                        <span class="copy-feedback" aria-live="polite"></span>
                     </div>
                     <div class="donate-item">
                         <img src="img/usdt_qr.png" alt="USDT TRC20 QR">
-                        <p>USDt TRC20: <code>TSxQ1aEvmTzjNZfYmXjrBMjuYNzEHRfi6T</code></p>
+                        <button class="btn btn-primary copy-address" data-address="TSxQ1aEvmTzjNZfYmXjrBMjuYNzEHRfi6T" data-ru="Скопировать USDT" data-en="Copy USDT">Скопировать USDT</button>
+                        <span class="copy-feedback" aria-live="polite"></span>
                     </div>
                 </div>
             </div>

--- a/css/contacts.css
+++ b/css/contacts.css
@@ -1,5 +1,9 @@
 /* Contacts Page Styles */
 
+body {
+  overflow-x: hidden;
+}
+
 /* Hero Section */
 .hero-section {
   padding: 8rem 0 4rem;
@@ -701,6 +705,16 @@
 .donate-item img {
   width: 160px;
   height: 160px;
+}
+
+.copy-address {
+  cursor: pointer;
+}
+
+.copy-feedback {
+  font-size: 0.875rem;
+  color: var(--color-green-600);
+  min-height: 1em;
 }
 
 /* Dark theme override for donate section */

--- a/js/contacts.js
+++ b/js/contacts.js
@@ -16,6 +16,7 @@ class ContactsPage {
     this.setupCharacterCounter()
     this.setupFAQ()
     this.setupFormSubmission()
+    this.setupCopyButtons()
     this.setupAccessibility()
   }
 
@@ -232,6 +233,29 @@ class ContactsPage {
     setTimeout(() => {
       this.successMessage.classList.remove("show")
     }, 10000)
+  }
+
+  setupCopyButtons() {
+    const buttons = document.querySelectorAll(".copy-address")
+
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const address = btn.getAttribute("data-address")
+        try {
+          await navigator.clipboard.writeText(address)
+          const feedback = btn.nextElementSibling
+          if (feedback) {
+            const text = document.documentElement.lang === "en" ? "Copied!" : "Скопировано!"
+            feedback.textContent = text
+            setTimeout(() => {
+              feedback.textContent = ""
+            }, 2000)
+          }
+        } catch (e) {
+          console.error("Copy failed", e)
+        }
+      })
+    })
   }
 
   setupAccessibility() {


### PR DESCRIPTION
## Summary
- disable horizontal scroll on contacts page
- hide wallet addresses behind copy buttons
- add script to copy wallet addresses to clipboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a03cf54d0832cbd5de69a61914f6d