### PR TITLE
Fix navigation highlight contrast in dark theme

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -147,4 +147,7 @@
     background-color: var(--color-stone-800);
     color: var(--color-primary);
   }
+  .nav-link.active {
+    color: var(--color-primary-900);
+  }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -271,6 +271,12 @@ a:focus {
   padding: var(--spacing-sm) var(--spacing-md);
 }
 
+@media (prefers-color-scheme: dark) {
+  .nav-link.active {
+    color: var(--color-primary-900);
+  }
+}
+
 .nav-link.active::after {
   display: none;
 }


### PR DESCRIPTION
## Summary
- tweak navigation styles for dark mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a1153735c832ca8594307a668269b