### PR TITLE
Fix blog titles and dynamic latest posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,49 +94,7 @@
                     <h2 class="section-title" data-ru="Последние записи" data-en="Latest posts">Последние записи</h2>
                     <a href="blog.html" class="section-link" data-ru="Все записи" data-en="All posts">Все записи →</a>
                 </div>
-                <div class="blog-grid">
-                    <article class="blog-card">
-                        <div class="card-content">
-                            <h3 class="card-title">
-                                <a href="post.html?file=post1.md" data-ru="Размышления о культуре" data-en="Thoughts on culture">
-                                    Размышления о культуре
-                                </a>
-                            </h3>
-                            <p class="card-excerpt" data-ru="Исследование современных культурных трендов и их влияния на общество..." data-en="Research on modern cultural trends and their impact on society...">
-                                Исследование современных культурных трендов и их влияния на общество...
-                            </p>
-                            <time class="card-date" datetime="2025-11-01">1 ноября 2025</time>
-                        </div>
-                    </article>
-
-                    <article class="blog-card">
-                        <div class="card-content">
-                            <h3 class="card-title">
-                                <a href="post.html?file=post2.md" data-ru="Технологии будущего" data-en="Future technologies">
-                                    Технологии будущего
-                                </a>
-                            </h3>
-                            <p class="card-excerpt" data-ru="Анализ перспективных технологических решений и их потенциала..." data-en="Analysis of promising technological solutions and their potential...">
-                                Анализ перспективных технологических решений и их потенциала...
-                            </p>
-                            <time class="card-date" datetime="2025-10-15">15 октября 2025</time>
-                        </div>
-                    </article>
-
-                    <article class="blog-card">
-                        <div class="card-content">
-                            <h3 class="card-title">
-                                <a href="post.html?file=post3.md" data-ru="Предпринимательство в IT" data-en="Entrepreneurship in IT">
-                                    Предпринимательство в IT
-                                </a>
-                            </h3>
-                            <p class="card-excerpt" data-ru="Опыт создания стартапов и работы в технологической сфере..." data-en="Experience in creating startups and working in the technology sector...">
-                                Опыт создания стартапов и работы в технологической сфере...
-                            </p>
-                            <time class="card-date" datetime="2025-09-30">30 сентября 2025</time>
-                        </div>
-                    </article>
-                </div>
+                <div class="blog-grid" id="latest-posts"></div>
             </div>
         </section>
     </main>
@@ -158,6 +116,7 @@
     </footer>
 
     <script src="js/announcements.js"></script>
+    <script src="js/blog-preview.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/blog-preview.js
+++ b/js/blog-preview.js
@@ -1,0 +1,121 @@
+class BlogPreview {
+  constructor() {
+    this.repo = 'dm1trienko/dm1trienko.github.io'
+    this.maxPosts = 3
+    this.loadPosts()
+  }
+
+  async loadPosts() {
+    const container = document.getElementById('latest-posts')
+    if (!container) return
+    container.textContent = 'Загрузка...'
+    try {
+      const api = `https://api.github.com/repos/${this.repo}/contents/posts`
+      const listRes = await fetch(api)
+      const files = (await listRes.json()).filter((f) => f.name.endsWith('.md'))
+
+      const posts = await Promise.all(
+        files.map(async (file) => {
+          const md = await fetch(file.download_url).then((r) => r.text())
+          const { meta, excerpt } = this.parseFrontmatter(md)
+          const title = meta.title || file.name.replace(/\.md$/i, '')
+          return {
+            file: file.name,
+            title,
+            date: meta.date || '',
+            excerpt,
+          }
+        })
+      )
+
+      posts.sort((a, b) => new Date(b.date) - new Date(a.date))
+      container.textContent = ''
+      posts.slice(0, this.maxPosts).forEach((post) => {
+        container.appendChild(this.renderCard(post))
+      })
+    } catch (e) {
+      container.textContent = 'Не удалось загрузить статьи'
+    }
+  }
+
+  parseFrontmatter(md) {
+    const match = md.match(/^---\n([\s\S]*?)\n---\n/)
+    const meta = {}
+    let body = md
+    if (match) {
+      match[1].split(/\n/).forEach((line) => {
+        const [k, ...r] = line.split(':')
+        let val = r.join(':').trim()
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1)
+        }
+        meta[k.trim()] = val
+      })
+      body = md.slice(match[0].length)
+    }
+    if (meta['дата'] && !meta.date) {
+      meta.date = this.parseDate(meta['дата'])
+    }
+    body = this.stripTitleFromContent(body, meta.title)
+    const excerpt = body
+      .trim()
+      .split(/\n{2,}/)[0]
+      .replace(/[#*_`>\[\]]/g, '')
+    return { meta, excerpt, content: body }
+  }
+
+  stripTitleFromContent(content, title) {
+    if (!title) return content
+    const lines = content.split(/\n/)
+    while (lines.length && lines[0].trim() === '') {
+      lines.shift()
+    }
+    if (lines[0] && /^#\s+/.test(lines[0])) {
+      const heading = lines[0].replace(/^#\s+/, '').trim()
+      if (heading === title) {
+        lines.shift()
+        if (lines.length && lines[0].trim() === '') lines.shift()
+      }
+    }
+    return lines.join('\n')
+  }
+
+  parseDate(str) {
+    const parts = str.split('.')
+    if (parts.length === 3) {
+      const [d, m, y] = parts
+      return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`
+    }
+    return str
+  }
+
+  formatDate(dateStr) {
+    if (!dateStr) return ''
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  renderCard(post) {
+    const card = document.createElement('article')
+    card.className = 'blog-card'
+    card.innerHTML = `
+      <div class="card-content">
+        <h3 class="card-title">
+          <a href="post.html?file=${encodeURIComponent(post.file)}">${post.title}</a>
+        </h3>
+        <p class="card-excerpt">${post.excerpt}</p>
+        <time class="card-date" datetime="${post.date}">${this.formatDate(post.date)}</time>
+      </div>
+    `
+    return card
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => new BlogPreview())

--- a/js/blog.js
+++ b/js/blog.js
@@ -22,9 +22,10 @@ class BlogPage {
         files.map(async (file) => {
           const md = await fetch(file.download_url).then((r) => r.text())
           const { meta, excerpt } = this.parseFrontmatter(md)
+          const title = meta.title || file.name.replace(/\.md$/i, '')
           return {
             file: file.name,
-            title: meta.title || file.name,
+            title,
             date: meta.date || '',
             excerpt,
           }


### PR DESCRIPTION
## Summary
- remove hardcoded posts from index
- dynamically load latest posts
- ensure blog titles hide `.md` extension

## Testing
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ac15e0604832cbae63eb3e408ea3b