### PR TITLE
Fix blog titles

### DIFF
--- a/js/blog-preview.js
+++ b/js/blog-preview.js
@@ -18,7 +18,8 @@ class BlogPreview {
         files.map(async (file) => {
           const md = await fetch(file.download_url).then((r) => r.text())
           const { meta, excerpt } = this.parseFrontmatter(md)
-          const title = meta.title || file.name.replace(/\.md$/i, '')
+          const rawTitle = meta.title || file.name
+          const title = rawTitle.replace(/\.md$/i, '')
           return {
             file: file.name,
             title,

--- a/js/blog.js
+++ b/js/blog.js
@@ -22,7 +22,8 @@ class BlogPage {
         files.map(async (file) => {
           const md = await fetch(file.download_url).then((r) => r.text())
           const { meta, excerpt } = this.parseFrontmatter(md)
-          const title = meta.title || file.name.replace(/\.md$/i, '')
+          const rawTitle = meta.title || file.name
+          const title = rawTitle.replace(/\.md$/i, '')
           return {
             file: file.name,
             title,

--- a/js/post.js
+++ b/js/post.js
@@ -13,11 +13,13 @@ class BlogPostPage {
       }
       const text = await res.text()
       const { meta, content } = this.parseFrontmatter(text)
+      const rawTitle = meta.title || file
+      const title = rawTitle.replace(/\.md$/i, '')
       const body = this.stripTitleFromContent(content, meta.title)
 
-      if (meta.title) {
-        document.getElementById('post-title').textContent = meta.title
-        document.title = meta.title + ' - Еремей Дмитриенко'
+      if (title) {
+        document.getElementById('post-title').textContent = title
+        document.title = title + ' - Еремей Дмитриенко'
       }
 
       if (meta.date) {


### PR DESCRIPTION
## Summary
- drop `.md` suffix from titles while reading posts
- apply title fix for blog listing, preview and single post pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2838008832c9e694b89ddbba697