### PR TITLE
Hide nav items on small screens

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -151,3 +151,20 @@
     color: var(--color-primary-900);
   }
 }
+
+@media (max-width: 768px) and (orientation: portrait) {
+  .nav-menu,
+  .language-selector {
+    display: none !important;
+  }
+
+  .navbar-container {
+    justify-content: center;
+    position: relative;
+  }
+
+  .nav-toggle {
+    position: absolute;
+    right: var(--spacing-lg);
+  }
+}


### PR DESCRIPTION
## Summary
- hide navigation menu and language switcher on very small screens
- center the header text when menu items are hidden

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac52bc9bc832ca5801944aebcbb7e