### PR TITLE
Fix mobile hamburger menu and language toggle

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -134,6 +134,18 @@
   .nav-toggle.active span:nth-child(3) {
     transform: rotate(-45deg) translate(7px, -6px);
   }
+
+  .language-selector {
+    display: none;
+  }
+
+  .nav-menu.active ~ .language-selector {
+    display: block;
+    position: fixed;
+    bottom: var(--spacing-lg);
+    left: 50%;
+    transform: translateX(-50%);
+  }
 }
 
 /* Active state for navigation links */
@@ -153,11 +165,6 @@
 }
 
 @media (max-width: 768px) and (orientation: portrait) {
-  .nav-menu,
-  .language-selector {
-    display: none !important;
-  }
-
   .navbar-container {
     justify-content: center;
     position: relative;
@@ -166,5 +173,7 @@
   .nav-toggle {
     position: absolute;
     right: var(--spacing-lg);
+    top: 50%;
+    transform: translateY(-50%);
   }
 }


### PR DESCRIPTION
## Summary
- remove leftover CSS that hid the nav menu on phones
- center hamburger toggle vertically on small screens
- show language selector at the bottom of the opened mobile menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ac91c14e8832c9ffe0cd6a13c19bf