### PR TITLE
Adjust navigation item alignment

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -33,7 +33,8 @@
   list-style: none;
   gap: var(--spacing-xl);
   margin: 0;
-  padding-top: var(--spacing-sm);
+  padding: 0;
+  height: 100%;
 }
 .nav-link {
   font-size: var(--font-size-lg);
@@ -136,7 +137,7 @@
   }
 
   .nav-menu .language-selector {
-    margin-top: auto;
+    margin-top: 0;
   }
 
   /* Keep close button fully visible */

--- a/css/styles.css
+++ b/css/styles.css
@@ -246,6 +246,7 @@ a:focus {
   gap: var(--spacing-xl);
   margin: 0;
   align-items: center;
+  height: 100%;
 }
 
 .nav-link {
@@ -416,7 +417,7 @@ a:focus {
   }
 
   .nav-menu .language-selector {
-    margin-top: auto;
+    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- center nav menu items by removing top padding and using full height
- keep language selector with other menu items on mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad0279f68832ca7f87b06e39544a8