### PR TITLE
Add dev warning to CultTech Hub page

### DIFF
--- a/css/culttech.css
+++ b/css/culttech.css
@@ -1,5 +1,15 @@
 /* CultTech Hub Specific Styles */
 
+.dev-warning {
+  background-color: var(--color-accent-50);
+  color: var(--color-primary);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
 /* Hero Section */
 .culttech-hero {
   min-height: 100vh;

--- a/culttech.html
+++ b/culttech.html
@@ -47,6 +47,9 @@
     <div class="progress-bar" id="progress-bar"></div>
 
     <main class="main">
+        <p class="dev-warning" data-ru="Эта вкладка находится в стадии разработки и может работать неправильно. Ее функционал и реализация еще не завершены." data-en="This page is under development and may not work as expected. Its functionality and implementation are not yet complete.">
+            Эта вкладка находится в стадии разработки и может работать неправильно. Ее функционал и реализация еще не завершены.
+        </p>
         <!-- Hero Section -->
         <section class="hero culttech-hero">
             <div class="container">


### PR DESCRIPTION
## Summary
- add warning banner that CulTech Hub is under development
- style the new development warning banner

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad1cfc3f4832c8841635e04b5b939