### PR TITLE
Add full bilingual roadmap page

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -68,11 +68,11 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2011–2013</div>
-                            <h3 class="timeline-title" data-en="Pre-school prep">Дошкольная подготовка</h3>
-                            <p class="timeline-description" data-en="Gymnastics and LEGO">Спортивная гимнастика — 2,5 года. LEGO-конструирование, базовые математические занятия.</p>
+                            <h3 class="timeline-title" data-en="Pre-school prep" data-ru="Дошкольная подготовка">Дошкольная подготовка</h3>
+                            <p class="timeline-description" data-en="Gymnastics for 2.5 years. LEGO construction and basic math lessons." data-ru="Спортивная гимнастика — 2,5 года. LEGO-конструирование, базовые математические занятия.">Спортивная гимнастика — 2,5 года. LEGO-конструирование, базовые математические занятия.</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Physical base">Физическая база</span>
-                                <span class="timeline-tag" data-en="Math interest">Математический интерес</span>
+                                <span class="timeline-tag" data-en="Physical base" data-ru="Физическая база">Физическая база</span>
+                                <span class="timeline-tag" data-en="Math interest" data-ru="Математический интерес">Математический интерес</span>
                             </div>
                         </div>
                     </div>
@@ -84,12 +84,12 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2013–2019</div>
-                            <h3 class="timeline-title" data-en="School foundation">Школьная основа (1–7&nbsp;кл.)</h3>
-                            <p class="timeline-description" data-en="English and cubing">программа Петерсон. Доп. английский. Хобби: головоломки и спидкубинг (avg&nbsp;&lt;&nbsp;20&nbsp;c).</p>
+                            <h3 class="timeline-title" data-en="School foundation" data-ru="Школьная основа (1–7&nbsp;кл.)">Школьная основа (1–7&nbsp;кл.)</h3>
+                            <p class="timeline-description" data-en="Peterson curriculum. Extra English classes. Hobbies: puzzles and speedcubing (avg < 20 s)." data-ru="программа Петерсон. Доп. английский. Хобби: головоломки и спидкубинг (avg&nbsp;&lt;&nbsp;20&nbsp;c).">программа Петерсон. Доп. английский. Хобби: головоломки и спидкубинг (avg&nbsp;&lt;&nbsp;20&nbsp;c).</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Math">Математика</span>
-                                <span class="timeline-tag" data-en="English">Английский</span>
-                                <span class="timeline-tag" data-en="Speedcubing">Speed-cubing</span>
+                                <span class="timeline-tag" data-en="Math" data-ru="Математика">Математика</span>
+                                <span class="timeline-tag" data-en="English" data-ru="Английский">Английский</span>
+                                <span class="timeline-tag" data-en="Speedcubing" data-ru="Speed-cubing">Speed-cubing</span>
                             </div>
                         </div>
                     </div>
@@ -101,11 +101,11 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2020–2021</div>
-                            <h3 class="timeline-title" data-en="8th grade breakthrough">8&nbsp;кл. — «олимпиадный щелчок»</h3>
-                            <p class="timeline-description" data-en="Regional prizes">Региональный призёр ВсОШ‑английский. Муниципальный призёр по истории. Год закрыт одними «5».</p>
+                            <h3 class="timeline-title" data-en="8th grade breakthrough" data-ru="8&nbsp;кл. — «олимпиадный щелчок»">8&nbsp;кл. — «олимпиадный щелчок»</h3>
+                            <p class="timeline-description" data-en="Regional prize in English Olympiad. Municipal prize in history. Finished the year with straight A's." data-ru="Региональный призёр ВсОШ‑английский. Муниципальный призёр по истории. Год закрыт одними «5».">Региональный призёр ВсОШ‑английский. Муниципальный призёр по истории. Год закрыт одними «5».</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Olympiad stamina">Олимпиадная устойчивость</span>
-                                <span class="timeline-tag" data-en="Time management">Time-management</span>
+                                <span class="timeline-tag" data-en="Olympiad stamina" data-ru="Олимпиадная устойчивость">Олимпиадная устойчивость</span>
+                                <span class="timeline-tag" data-en="Time management" data-ru="Time-management">Time-management</span>
                             </div>
                         </div>
                     </div>
@@ -117,12 +117,12 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2021–2022</div>
-                            <h3 class="timeline-title" data-en="9th grade to IT">9&nbsp;кл. — разворот к IT</h3>
-                            <p class="timeline-description" data-en="OGE and IQ">ОГЭ: англ. + информатика&nbsp;— «5». IQ&nbsp;150. Сертификат SSI Freediving (базовый).</p>
+                            <h3 class="timeline-title" data-en="9th grade to IT" data-ru="9&nbsp;кл. — разворот к IT">9&nbsp;кл. — разворот к IT</h3>
+                            <p class="timeline-description" data-en="OGE exams in English and Informatics — all A's. IQ 150. SSI Freediving certificate (basic)." data-ru="ОГЭ: англ. + информатика&nbsp;— «5». IQ&nbsp;150. Сертификат SSI Freediving (базовый).">ОГЭ: англ. + информатика&nbsp;— «5». IQ&nbsp;150. Сертификат SSI Freediving (базовый).</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Python start">Python Start</span>
-                                <span class="timeline-tag" data-en="IQ 150">IQ&nbsp;150</span>
-                                <span class="timeline-tag" data-en="Self-management">Самоорганизация</span>
+                                <span class="timeline-tag" data-en="Python start" data-ru="Python Start">Python Start</span>
+                                <span class="timeline-tag" data-en="IQ 150" data-ru="IQ&nbsp;150">IQ&nbsp;150</span>
+                                <span class="timeline-tag" data-en="Self-management" data-ru="Самоорганизация">Самоорганизация</span>
                             </div>
                         </div>
                     </div>
@@ -134,12 +134,12 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2022–2023</div>
-                            <h3 class="timeline-title" data-en="10th grade math mode">10&nbsp;кл. — математический режим</h3>
-                            <p class="timeline-description" data-en="Tutors and olympiads">Репетиторы МГУ и МФТИ, онлайн‑курсы. Победитель олимпиады «Газпром», диплом II Фоксфорда. Pers. freediving record&nbsp;— 4&nbsp;мин&nbsp;00&nbsp;с.</p>
+                            <h3 class="timeline-title" data-en="10th grade math mode" data-ru="10&nbsp;кл. — математический режим">10&nbsp;кл. — математический режим</h3>
+                            <p class="timeline-description" data-en="MSU and MIPT tutors, online courses. Winner of Gazprom Olympiad, Foxford diploma II. Personal freediving record — 4:00." data-ru="Репетиторы МГУ и МФТИ, онлайн‑курсы. Победитель олимпиады «Газпром», диплом II Фоксфорда. Pers. freediving record&nbsp;— 4&nbsp;мин&nbsp;00&nbsp;с.">Репетиторы МГУ и МФТИ, онлайн‑курсы. Победитель олимпиады «Газпром», диплом II Фоксфорда. Pers. freediving record&nbsp;— 4&nbsp;мин&nbsp;00&nbsp;с.</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Algebra 2.0">Алгебра&nbsp;2.0</span>
-                                <span class="timeline-tag" data-en="Olympiad TOP">Олимпиада&nbsp;TOP</span>
-                                <span class="timeline-tag" data-en="Freediving 4:00">Freediving&nbsp;4:00</span>
+                                <span class="timeline-tag" data-en="Algebra 2.0" data-ru="Алгебра&nbsp;2.0">Алгебра&nbsp;2.0</span>
+                                <span class="timeline-tag" data-en="Olympiad TOP" data-ru="Олимпиада&nbsp;TOP">Олимпиада&nbsp;TOP</span>
+                                <span class="timeline-tag" data-en="Freediving 4:00" data-ru="Freediving&nbsp;4:00">Freediving&nbsp;4:00</span>
                             </div>
                         </div>
                     </div>
@@ -151,12 +151,12 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">2023–2024</div>
-                            <h3 class="timeline-title" data-en="11th grade sprint">11&nbsp;кл. — спурт к Физтеху</h3>
-                            <p class="timeline-description" data-en="Olympiad wins and project">Победитель Яндекс‑олимпиады. Призёр «Физтех»-олимпиады. Проект Heritage‑NFT. ЕГЭ: М&nbsp;96, Р&nbsp;89*</p>
+                            <h3 class="timeline-title" data-en="11th grade sprint" data-ru="11&nbsp;кл. — спурт к Физтеху">11&nbsp;кл. — спурт к Физтеху</h3>
+                            <p class="timeline-description" data-en="Winner of the Yandex Olympiad. Prizewinner of the Phystech Olympiad. Heritage-NFT project. USE: Math 96, Russian 89*." data-ru="Победитель Яндекс‑олимпиады. Призёр «Физтех»-олимпиады. Проект Heritage‑NFT. ЕГЭ: М&nbsp;96, Р&nbsp;89*">Победитель Яндекс‑олимпиады. Призёр «Физтех»-олимпиады. Проект Heritage‑NFT. ЕГЭ: М&nbsp;96, Р&nbsp;89*</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="Yandex">Яндекс</span>
-                                <span class="timeline-tag" data-en="MIPT">Физтех</span>
-                                <span class="timeline-tag" data-en="Heritage NFT">Heritage‑NFT</span>
+                                <span class="timeline-tag" data-en="Yandex" data-ru="Яндекс">Яндекс</span>
+                                <span class="timeline-tag" data-en="MIPT" data-ru="Физтех">Физтех</span>
+                                <span class="timeline-tag" data-en="Heritage NFT" data-ru="Heritage‑NFT">Heritage‑NFT</span>
                             </div>
                         </div>
                     </div>
@@ -168,11 +168,11 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">Июн – Авг&nbsp;2024</div>
-                            <h3 class="timeline-title" data-en="Graduation to MIPT">Выпуск → МФТИ</h3>
-                            <p class="timeline-description" data-en="Admission with grant">Поздравление главы Подольска. Рекомендации «Школково» и наставника. Зачислен на ФПМИ МФТИ, получен грант.</p>
+                            <h3 class="timeline-title" data-en="Graduation to MIPT" data-ru="Выпуск → МФТИ">Выпуск → МФТИ</h3>
+                            <p class="timeline-description" data-en="Congratulations from the head of Podolsk. Recommendations from 'Shkolkovo' and mentor. Enrolled in MIPT FPMI with a grant." data-ru="Поздравление главы Подольска. Рекомендации «Школково» и наставника. Зачислен на ФПМИ МФТИ, получен грант.">Поздравление главы Подольска. Рекомендации «Школково» и наставника. Зачислен на ФПМИ МФТИ, получен грант.</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag" data-en="MIPT start">Физтех-старт</span>
-                                <span class="timeline-tag" data-en="Grant">Грант</span>
+                                <span class="timeline-tag" data-en="MIPT start" data-ru="Физтех-старт">Физтех-старт</span>
+                                <span class="timeline-tag" data-en="Grant" data-ru="Грант">Грант</span>
                             </div>
                         </div>
                     </div>
@@ -184,13 +184,13 @@
                         </div>
                         <div class="timeline-content">
                             <div class="timeline-date">Сент&nbsp;2024 – Авг&nbsp;2025</div>
-                            <h3 class="timeline-title" data-en="Reset & Upgrade">Академ-пауза / фаза «Reset&nbsp;&amp;&nbsp;Upgrade»</h3>
-                            <p class="timeline-description" data-en="Blockchain and cycling">Углублённое изучение blockchain-технологий. Возврат к велоспорту 50&nbsp;км+ в неделю. Переосмысление приоритетов и онлайн-учёба. Получение водительских прав летом&nbsp;2025.</p>
+                            <h3 class="timeline-title" data-en="Reset & Upgrade" data-ru="Академ-пауза / фаза «Reset&nbsp;&amp;&nbsp;Upgrade»">Академ-пауза / фаза «Reset&nbsp;&amp;&nbsp;Upgrade»</h3>
+                            <p class="timeline-description" data-en="In-depth study of blockchain technologies. Return to cycling 50+ km per week. Re-evaluating priorities and online learning. Driver's license in summer 2025." data-ru="Углублённое изучение blockchain-технологий. Возврат к велоспорту 50&nbsp;км+ в неделю. Переосмысление приоритетов и онлайн-учёба. Получение водительских прав летом&nbsp;2025.">Углублённое изучение blockchain-технологий. Возврат к велоспорту 50&nbsp;км+ в неделю. Переосмысление приоритетов и онлайн-учёба. Получение водительских прав летом&nbsp;2025.</p>
                             <div class="timeline-tags">
-                                <span class="timeline-tag current" data-en="Blockchain">Blockchain fundamentals</span>
-                                <span class="timeline-tag" data-en="Endurance">Endurance &amp; habits</span>
-                                <span class="timeline-tag" data-en="Reflection">Self-reflection</span>
-                                <span class="timeline-tag" data-en="Distance learning">Distance-learning discipline</span>
+                                <span class="timeline-tag current" data-en="Blockchain fundamentals" data-ru="Основы blockchain">Основы blockchain</span>
+                                <span class="timeline-tag" data-en="Endurance &amp; habits" data-ru="Выносливость и привычки">Выносливость и привычки</span>
+                                <span class="timeline-tag" data-en="Self-reflection" data-ru="Саморефлексия">Саморефлексия</span>
+                                <span class="timeline-tag" data-en="Distance-learning discipline" data-ru="Дисциплина онлайн-обучения">Дисциплина онлайн-обучения</span>
                             </div>
                         </div>
                     </div>
@@ -200,28 +200,28 @@
         <!-- Stats Section -->
         <section class="stats-section">
             <div class="container">
-                <h2 class="section-title" data-en="Journey in Numbers">Путь в цифрах</h2>
+                <h2 class="section-title" data-en="Journey in Numbers" data-ru="Путь в цифрах">Путь в цифрах</h2>
                 <div class="stats-grid">
                     <div class="stat-item">
                         <div class="stat-number">14</div>
-                        <div class="stat-label" data-en="Countries Visited">Стран посещено</div>
+                        <div class="stat-label" data-en="Countries Visited" data-ru="Стран посещено">Стран посещено</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">3</div>
-                        <div class="stat-label" data-en="Major Olympiads">Олимпиады‑«титаны»</div>
+                        <div class="stat-label" data-en="Major Olympiads" data-ru="Олимпиады‑«титаны»">Олимпиады‑«титаны»</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">5</div>
-                        <div class="stat-label" data-en="Certificates">Сертификаты</div>
+                        <div class="stat-label" data-en="Certificates" data-ru="Сертификаты">Сертификаты</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">285</div>
-                        <div class="stat-label" data-en="Unified State Exam Score">Баллы ЕГЭ</div>
+                        <div class="stat-label" data-en="Unified State Exam Score" data-ru="Баллы ЕГЭ">Баллы ЕГЭ</div>
                     </div>
                 </div>
             </div>
         </section>
-        <p class="timeline-footnote" data-en="* Key milestones only; full list available on request.">* Приведены самые показательные точки; полный перечень достижений доступен по запросу.</p>
+        <p class="timeline-footnote" data-en="* Key milestones only; full list available on request." data-ru="* Приведены самые показательные точки; полный перечень достижений доступен по запросу.">* Приведены самые показательные точки; полный перечень достижений доступен по запросу.</p>
     </main>
 
     <!-- Footer -->


### PR DESCRIPTION
## Summary
- make Roadmap page bilingual
- supply missing `data-ru` attributes
- expand English translations for timeline

## Testing
- `npm run build` *(fails: no build script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad17cb12c832c9cd6564df67cb2ea