### PR TITLE
Implement dark theme styles for contacts social block

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -603,6 +603,7 @@ body {
   .donate-section code {
     color: var(--color-stone-100);
   }
+
 }
 
 /* Responsive Design */
@@ -772,7 +773,7 @@ body {
   color: var(--color-stone-600);
 }
 
-/* Dark theme override for donate section */
+/* Dark theme overrides for donate section and social links */
 @media (prefers-color-scheme: dark) {
   .donate-section {
     background: var(--color-stone-900);
@@ -795,5 +796,13 @@ body {
   .donate-section .copy-address:active {
     background: var(--color-stone-500);
     color: var(--color-stone-100);
+  }
+
+  .social-links {
+    background: var(--color-stone-900);
+  }
+
+  .social-note {
+    color: var(--color-stone-300);
   }
 }


### PR DESCRIPTION
## Summary
- add dark mode styling for the contacts social media block
- ensure dark overrides come after default rules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad41935bc832c9e8e4df56adad521