### PR TITLE
Fix dark theme for contacts social bar

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -604,13 +604,6 @@ body {
     color: var(--color-stone-100);
   }
 
-  .social-links {
-    background: var(--color-stone-900);
-  }
-
-  .social-note {
-    color: var(--color-stone-300);
-  }
 }
 
 /* Responsive Design */
@@ -784,6 +777,15 @@ body {
 @media (prefers-color-scheme: dark) {
   .donate-section {
     background: var(--color-stone-900);
+  }
+
+  /* Social links dark theme */
+  .social-links {
+    background: var(--color-stone-900);
+  }
+
+  .social-note {
+    color: var(--color-stone-300);
   }
 
   .donate-section .section-title {


### PR DESCRIPTION
## Summary
- ensure dark mode styles for the social links block override light styles in `contacts.html`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad661c370832c9e331ee97f9aba09