### PR TITLE
Fix blog post modal and page for spaces

### DIFF
--- a/css/culttech.css
+++ b/css/culttech.css
@@ -292,6 +292,31 @@
   cursor: pointer;
 }
 
+.map-point--moscow {
+  top: 30%;
+  left: 55%;
+}
+
+.map-point--spb {
+  top: 25%;
+  left: 52%;
+}
+
+.map-point--london {
+  top: 35%;
+  left: 45%;
+}
+
+.map-point--ny {
+  top: 40%;
+  left: 25%;
+}
+
+.map-point--berlin {
+  top: 32%;
+  left: 48%;
+}
+
 .map-marker {
   width: 40px;
   height: 40px;

--- a/culttech.html
+++ b/culttech.html
@@ -408,11 +408,10 @@
           <div class="map-container">
             <div class="interactive-map" id="community-map">
               <!-- Moscow -->
-              <div
-                class="map-point"
-                style="top: 30%; left: 55%"
-                data-city="moscow"
-              >
+                <div
+                  class="map-point map-point--moscow"
+                  data-city="moscow"
+                >
                 <div class="map-marker">
                   <span class="marker-count">12</span>
                 </div>
@@ -425,11 +424,10 @@
               </div>
 
               <!-- St. Petersburg -->
-              <div
-                class="map-point"
-                style="top: 25%; left: 52%"
-                data-city="spb"
-              >
+                <div
+                  class="map-point map-point--spb"
+                  data-city="spb"
+                >
                 <div class="map-marker">
                   <span class="marker-count">8</span>
                 </div>
@@ -442,11 +440,10 @@
               </div>
 
               <!-- London -->
-              <div
-                class="map-point"
-                style="top: 35%; left: 45%"
-                data-city="london"
-              >
+                <div
+                  class="map-point map-point--london"
+                  data-city="london"
+                >
                 <div class="map-marker">
                   <span class="marker-count">15</span>
                 </div>
@@ -459,7 +456,7 @@
               </div>
 
               <!-- New York -->
-              <div class="map-point" style="top: 40%; left: 25%" data-city="ny">
+                <div class="map-point map-point--ny" data-city="ny">
                 <div class="map-marker">
                   <span class="marker-count">23</span>
                 </div>
@@ -472,11 +469,10 @@
               </div>
 
               <!-- Berlin -->
-              <div
-                class="map-point"
-                style="top: 32%; left: 48%"
-                data-city="berlin"
-              >
+                <div
+                  class="map-point map-point--berlin"
+                  data-city="berlin"
+                >
                 <div class="map-marker">
                   <span class="marker-count">11</span>
                 </div>
@@ -547,12 +543,12 @@
                   </label>
                   <div class="checkbox-group">
                     <label class="checkbox-label">
-                      <input type="checkbox" name="interests" value="culture" />
+                      <input type="checkbox" name="interests[]" value="culture" />
                       <span class="checkbox-custom"></span>
                       <span data-ru="Культура" data-en="Culture">Культура</span>
                     </label>
                     <label class="checkbox-label">
-                      <input type="checkbox" name="interests" value="tech" />
+                      <input type="checkbox" name="interests[]" value="tech" />
                       <span class="checkbox-custom"></span>
                       <span data-ru="Технологии" data-en="Technology"
                         >Технологии</span
@@ -561,7 +557,7 @@
                     <label class="checkbox-label">
                       <input
                         type="checkbox"
-                        name="interests"
+                        name="interests[]"
                         value="business"
                       />
                       <span class="checkbox-custom"></span>

--- a/js/blog.js
+++ b/js/blog.js
@@ -145,7 +145,8 @@ class BlogPage {
 
   async openPost(file) {
     try {
-      const res = await fetch('posts/' + file)
+      const url = 'posts/' + encodeURIComponent(file)
+      const res = await fetch(url)
       if (!res.ok) throw new Error(res.statusText)
       const md = await res.text()
       const { meta, content } = this.parseFrontmatter(md)

--- a/js/post.js
+++ b/js/post.js
@@ -7,7 +7,8 @@ class BlogPostPage {
       return
     }
     try {
-      const res = await fetch('posts/' + file)
+      const url = 'posts/' + encodeURIComponent(file)
+      const res = await fetch(url)
       if (!res.ok) {
         throw new Error(res.status + ' ' + res.statusText)
       }

--- a/yandex_53c4b06fa61ba4b9.html
+++ b/yandex_53c4b06fa61ba4b9.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Yandex Site Verification</title>
   </head>
   <body>
     Verification: 53c4b06fa61ba4b9


### PR DESCRIPTION
## Summary
- encode filenames when loading posts from blog grid
- encode filenames when opening standalone post page
- move map-point positions to CSS and allow interest checkboxes
- add title to Yandex verification page
- remove .htmlvalidateignore and fix lint issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d32b5c420832c8ddde66401ffe8bb