### PR TITLE
Improve mobile mini-game

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -9,6 +9,8 @@
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   display: block;
+  width: 100%;
+  height: auto;
   margin: 0 auto var(--spacing-md);
 }
 

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
           <h2 class="section-title" data-ru="Мини-игра" data-en="Mini Game">
             Мини-игра
           </h2>
-          <canvas id="game-canvas" width="600" height="200"></canvas>
+          <canvas id="game-canvas"></canvas>
           <button
             id="game-start"
             class="btn btn-primary"

--- a/js/game.js
+++ b/js/game.js
@@ -4,6 +4,8 @@ class MiniRunner {
     this.btn = document.getElementById(startBtnId)
     if (!this.canvas || !this.btn) return
     this.ctx = this.canvas.getContext('2d')
+    this.resizeCanvas()
+    window.addEventListener('resize', () => this.resizeCanvas())
     this.bindEvents()
     this.reset()
   }
@@ -13,6 +15,18 @@ class MiniRunner {
     window.addEventListener('keydown', (e) => {
       if (e.code === 'Space') this.jump()
     })
+    this.canvas.addEventListener('mousedown', () => this.jump())
+    this.canvas.addEventListener('touchstart', (e) => {
+      e.preventDefault()
+      this.jump()
+    })
+  }
+
+  resizeCanvas() {
+    const ratio = 3
+    const width = this.canvas.parentElement.clientWidth
+    this.canvas.width = width
+    this.canvas.height = width / ratio
   }
 
   reset() {


### PR DESCRIPTION
## Summary
- make the mini-game canvas responsive
- allow tap or click on the canvas to jump
- resize the canvas on window resize
- remove fixed width/height from the canvas element

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d869a9850832c88b9100159081de4