### PR TITLE
Improve Mario embed with external controls

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -22,3 +22,43 @@
   color: var(--color-white);
   cursor: pointer;
 }
+
+.game-frame {
+  border: 4px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.game-frame iframe {
+  display: block;
+  width: 100%;
+  height: 512px;
+  border: none;
+}
+
+#mario-controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+#mario-controls .control {
+  width: auto;
+  height: auto;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  background: #2563eb;
+  color: #fff;
+  font-family: 'Inter', sans-serif;
+  box-shadow: none;
+  transition: background 0.2s;
+}
+
+#mario-controls .control:hover {
+  background: #1e40af;
+}

--- a/index.html
+++ b/index.html
@@ -162,12 +162,15 @@
           <h2 class="section-title" data-ru="Мини-игра" data-en="Mini Game">
             Мини-игра
           </h2>
-          <iframe
-            src="mario/index.html"
-            id="mario-game"
-            title="Super Mario"
-            style="width: 100%; height: 512px; border: none"
-          ></iframe>
+          <div class="game-frame">
+            <iframe
+              src="mario/index.html"
+              id="mario-game"
+              title="Super Mario"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div id="mario-controls"></div>
         </div>
       </section>
 
@@ -263,6 +266,7 @@
 
     <script type="module" src="js/announcements.js" defer></script>
     <script type="module" src="js/blog-preview.js" defer></script>
+    <script type="module" src="js/mario-frame.js" defer></script>
     <script type="module" src="js/main.js" defer></script>
   </body>
 </html>

--- a/js/mario-frame.js
+++ b/js/mario-frame.js
@@ -1,0 +1,29 @@
+// Move Mario game controls outside the iframe once it loads
+
+export function initMarioFrame() {
+  const iframe = document.getElementById('mario-game')
+  const controlsContainer = document.getElementById('mario-controls')
+  if (!iframe || !controlsContainer) return
+
+  iframe.addEventListener('load', () => {
+    try {
+      const innerDoc = iframe.contentDocument || iframe.contentWindow.document
+      const controls = innerDoc.getElementById('controls')
+      if (controls) {
+        // remove from iframe and adopt into outer document
+        controls.remove()
+        document.adoptNode(controls)
+        controlsContainer.appendChild(controls)
+      }
+    } catch (err) {
+      console.error('Failed to move Mario controls', err)
+    }
+  })
+}
+
+// Initialize on DOM ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMarioFrame)
+} else {
+  initMarioFrame()
+}


### PR DESCRIPTION
## Summary
- style the Mario embed with a frame
- move control buttons below the game
- add script to relocate controls from the iframe

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' / thousands of linter errors)*

------
https://chatgpt.com/codex/tasks/task_e_684db22fc3e0832ca1e7bc23547731cf