### PR TITLE
Adjust Mario screen and controls

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -28,14 +28,15 @@
   border-radius: var(--border-radius-lg);
   overflow: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  max-width: 800px;
+  max-width: 100%;
   margin: 0 auto;
 }
 
 .game-frame iframe {
   display: block;
   width: 100%;
-  height: 512px;
+  aspect-ratio: 512 / 464;
+  height: auto;
   border: none;
 }
 
@@ -57,8 +58,27 @@
   font-family: 'Inter', sans-serif;
   box-shadow: none;
   transition: background 0.2s;
+  cursor: pointer;
+  position: relative;
 }
 
 #mario-controls .control:hover {
   background: #1e40af;
+}
+
+#mario-controls .control .control-inner {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  z-index: 10;
+}
+
+#mario-controls .control[active='on'] .control-inner {
+  display: block;
+}
+
+#mario-controls.length-4 .control,
+#mario-controls.length-5 .control {
+  min-width: auto;
 }

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <meta name="twitter:card" content="summary" />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/navigation.css" />
+    <link rel="stylesheet" href="css/game.css" />
     <link rel="manifest" href="manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/js/mario-frame.js
+++ b/js/mario-frame.js
@@ -14,6 +14,17 @@ export function initMarioFrame() {
         controls.remove()
         document.adoptNode(controls)
         controlsContainer.appendChild(controls)
+
+        // make controls clickable instead of hover-based
+        const buttons = controls.querySelectorAll('.control')
+        buttons.forEach((btn) => {
+          btn.onmouseover = null
+          btn.onmouseout = null
+          btn.addEventListener('click', () => {
+            const isActive = btn.getAttribute('active') === 'on'
+            btn.setAttribute('active', isActive ? 'off' : 'on')
+          })
+        })
       }
     } catch (err) {
       console.error('Failed to move Mario controls', err)


### PR DESCRIPTION
## Summary
- link game.css explicitly
- make the Mario frame responsive
- style controls and support click toggling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_684db6258650832cadd81226811da792