### PR TITLE
Fix Mario game visibility

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -49,8 +49,8 @@
 .game-frame iframe {
   display: block;
   width: 100%;
-  /* Increase visible area so Mario isn't cut off */
-  aspect-ratio: 512 / 480;
+  /* Further expand height to show Mario completely */
+  aspect-ratio: 512 / 600;
   height: auto;
   border: none;
 }

--- a/js/mario-frame.js
+++ b/js/mario-frame.js
@@ -5,17 +5,16 @@ export function initMarioFrame() {
   const controlsContainer = document.getElementById('mario-controls')
   if (!iframe || !controlsContainer) return
 
-  iframe.addEventListener('load', () => {
+  function moveControls() {
     try {
       const innerDoc = iframe.contentDocument || iframe.contentWindow.document
       const controls = innerDoc.getElementById('controls')
-      if (controls) {
-        // remove from iframe and adopt into outer document
+      if (controls && controls.childElementCount > 0) {
+        clearInterval(waiter)
         controls.remove()
         document.adoptNode(controls)
         controlsContainer.appendChild(controls)
 
-        // make controls clickable instead of hover-based
         const buttons = controls.querySelectorAll('.control')
         buttons.forEach((btn) => {
           btn.onmouseover = null
@@ -27,8 +26,16 @@ export function initMarioFrame() {
         })
       }
     } catch (err) {
+      clearInterval(waiter)
       console.error('Failed to move Mario controls', err)
     }
+  }
+
+  let waiter
+  iframe.addEventListener('load', () => {
+    moveControls()
+    waiter = setInterval(moveControls, 200)
+    setTimeout(() => clearInterval(waiter), 5000)
   })
 }
 


### PR DESCRIPTION
## Summary
- increase iframe height ratio so full Mario game renders
- ensure Mario game controls load outside iframe using a polling strategy

## Testing
- `npm run lint` *(fails: cannot find '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_684dbe8372b8832c9ce08539ec1141e3