### PR TITLE
Adjust Mario iframe size

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -42,7 +42,8 @@
   border-radius: var(--border-radius-lg);
   overflow: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  max-width: 100%;
+  max-width: 600px;
+  width: 100%;
   margin: 0 auto;
 }
 

--- a/mario/assets/index.css
+++ b/mario/assets/index.css
@@ -338,7 +338,7 @@ section.section-text {
 /* GameBoy-like container for mobile */
 #gameboy {
     width: 100%;
-    max-width: none;
+    max-width: 600px;
     margin: 0 auto;
     padding: 20px;
     background: #cfcfcf;


### PR DESCRIPTION
## Summary
- resize the embedded Mario block
- cap width of game container in `mario/index.html`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_684dd3fb4f70832cb8c76cf630928dd6