### PR TITLE
Fix Mario iframe ratio on mobile

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -58,7 +58,8 @@
 
 @media (max-width: 600px) {
   .game-frame iframe {
-    aspect-ratio: 1 / 1;
+    /* Keep original proportion so game is fully visible */
+    aspect-ratio: 512 / 600;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep original aspect ratio on small screens for Mario iframe

## Testing
- `npm install`
- `npm run lint` *(fails: 80405 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684de8416f98832c8f475b898cf75c7c