### PR TITLE
Adjust Mario game aspect ratio

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -50,16 +50,16 @@
 .game-frame iframe {
   display: block;
   width: 100%;
-  /* Further expand height to show Mario completely */
-  aspect-ratio: 512 / 600;
+  /* Maintain 10:9 proportion for consistent sizing */
+  aspect-ratio: 10 / 9;
   height: auto;
   border: none;
 }
 
 @media (max-width: 600px) {
   .game-frame iframe {
-    /* Keep original proportion so game is fully visible */
-    aspect-ratio: 512 / 600;
+    /* Keep same 10:9 ratio on small screens */
+    aspect-ratio: 10 / 9;
   }
 }
 


### PR DESCRIPTION
## Summary
- maintain 10:9 aspect ratio for the embedded Mario game across devices

## Testing
- `npm install`
- `npm run lint` *(fails: Expected indentation errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_684df1ef860c832c8349388e4f9d1473