### PR TITLE
Fix Mario frame width on mobile

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -52,8 +52,7 @@
   width: 100%;
   /* Real playable area is about 600x512 so use that ratio */
   aspect-ratio: 75 / 64;
-  /* Ensure the full game fits on narrow screens */
-  min-height: 512px;
+  height: auto;
   border: none;
 }
 
@@ -61,7 +60,7 @@
   .game-frame iframe {
     /* Keep consistent ratio on small screens */
     aspect-ratio: 75 / 64;
-    min-height: 512px;
+    height: auto;
   }
 }
 

--- a/mario/assets/index.css
+++ b/mario/assets/index.css
@@ -345,6 +345,7 @@ section.section-text {
     background: #cfcfcf;
     border: 4px solid #999;
     border-radius: 12px;
+    overflow: hidden;
 }
 
 #mobile-controls {


### PR DESCRIPTION
## Summary
- allow iframe height to auto-fit so the Mario game scales with screen width
- prevent scrolling inside the game container

## Testing
- `npm run lint` *(fails: 80405 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe0add9c832c984c652466377ef2