### PR TITLE
Fix Mario game viewport

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -1,7 +1,23 @@
 #mini-game {
-  padding: var(--spacing-3xl) 0;
+  padding: 0;
   text-align: center;
   background-color: var(--color-surface);
+  overflow: hidden;
+  height: 100vh;
+  width: 100vw;
+  position: relative;
+}
+
+#mini-game .container {
+  max-width: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+
+#mini-game .section-title {
+  display: none;
 }
 
 #mini-game canvas {
@@ -38,29 +54,28 @@
 }
 
 .game-frame {
-  border: 4px solid var(--color-border);
-  border-radius: var(--border-radius-lg);
+  border: none;
+  border-radius: 0;
   overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  max-width: 600px;
-  width: 100%;
-  margin: 0 auto;
+  box-shadow: none;
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
 }
 
 .game-frame iframe {
   display: block;
   width: 100%;
-  /* Real playable area is about 600x512 so use that ratio */
-  aspect-ratio: 75 / 64;
-  height: auto;
+  height: 100%;
   border: none;
 }
 
 @media (max-width: 600px) {
+  .game-frame,
   .game-frame iframe {
-    /* Keep consistent ratio on small screens */
-    aspect-ratio: 75 / 64;
-    height: auto;
+    width: 100vw;
+    height: 100vh;
   }
 }
 
@@ -68,7 +83,12 @@
   display: flex;
   justify-content: center;
   gap: var(--spacing-md);
-  margin-top: var(--spacing-md);
+  position: absolute;
+  left: 50%;
+  bottom: var(--spacing-md);
+  transform: translateX(-50%);
+  margin: 0;
+  width: max-content;
 }
 
 #mario-controls .control {

--- a/mario/assets/index.css
+++ b/mario/assets/index.css
@@ -13,7 +13,7 @@ body {
     background: #cfcfcf;
     color: #fafafa;
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: hidden;
 }
 
 header {
@@ -338,13 +338,14 @@ section.section-text {
 
 /* GameBoy-like container for mobile */
 #gameboy {
-    width: 100%;
-    max-width: 600px;
-    margin: 0 auto;
-    padding: 20px;
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    margin: 0;
+    padding: 0;
     background: #cfcfcf;
-    border: 4px solid #999;
-    border-radius: 12px;
+    border: none;
+    border-radius: 0;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- make mini-game section fill the viewport without scrolling
- disable scrolling in the Mario game frame
- stretch `#gameboy` container to full screen

## Testing
- `npm run lint` *(fails: many style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684dffff7e04832c83814406ffdb945d